### PR TITLE
Analysis

### DIFF
--- a/flash_attention_softmax_n/analysis/hooks.py
+++ b/flash_attention_softmax_n/analysis/hooks.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from functools import partial
-from typing import DefaultDict, Tuple, Optional, List, Dict, Union
+from typing import DefaultDict, Tuple, Optional, Set, Dict
+from warnings import warn
 
 from torch import Tensor, no_grad, mean
 from torch.nn import Module
@@ -15,6 +16,14 @@ from flash_attention_softmax_n.analysis.statistics import (
 )
 
 
+_activation_stat_funcs = {
+        'kurtosis': kurtosis_batch_mean,
+        'skewness': skewness_batch_mean,
+        'variance': variance_batch_mean,
+        'mean': lambda x: mean(x).item()
+    }
+
+
 @no_grad()
 def save_activations_statistics(
         activations: DefaultDict,
@@ -27,28 +36,30 @@ def save_activations_statistics(
     PyTorch Forward hook to compute the online average of statistics at each forward pass.
     Mutates specified dict objects with each fwd pass.
     """
-    batch_size = out.shape[0]
-    batch_weight = batch_size / (activations[name]['n_samples'] + batch_size)
-    activations[name]['n_samples'] += batch_size
+    try:
+        batch_size = out.shape[0]
+        batch_weight = batch_size / (activations[name]['n_samples'] + batch_size)
+        activations[name]['n_samples'] += batch_size
 
-    stat_funcs = {
-        'kurtosis': kurtosis_batch_mean,
-        'skewness': skewness_batch_mean,
-        'variance': variance_batch_mean,
-        'mean': lambda x: mean(x).item()
-    }
+        # new_value == (1 - weight) * current_value + weight * update_value
+        for stat, func in _activation_stat_funcs.items():
+            # Down-weight the current value
+            activations[name][stat] *= (1 - batch_weight)
+            # Add the weighted new value
+            activations[name][stat] += batch_weight * func(out)
 
-    for stat, func in stat_funcs.items():
-        # Down-weight the current value
-        activations[name][stat] *= (1 - batch_weight)
-        # Add the weighted new value
-        activations[name][stat] += batch_weight * func(out)
+    except AttributeError as e:
+        warn(f"Unable to compute stats for module {name}. Consider setting or updating `layers_to_save` in `register_activation_hooks`. {e}.", UserWarning)
+
+
+def _check_name(name: str, layers_to_save: Optional[Set[str]] = None) -> bool:
+    return (layers_to_save is None and 'attention.output' in name) or (layers_to_save is not None and name in layers_to_save)
 
 
 def register_activation_hooks(
         model: Module,
-        layers_to_save: Optional[List[str]] = None
-) -> DefaultDict[str, Dict[str, Union[int, float]]]:
+        layers_to_save: Optional[Set[str]] = None
+) -> DefaultDict[str, DefaultDict[str, float]]:
     """Registers forward hooks in specified layers.
     Parameters
     ----------
@@ -63,19 +74,14 @@ def register_activation_hooks(
         dict of dicts containing activations of specified layers in
         ``layers_to_save``.
     """
-    activations_dict = defaultdict(lambda: {
-        'n_samples': 0,
-        'kurtosis': 0.,
-        'skewness': 0.,
-        'variance': 0.,
-        'mean': 0.
-    })
+    activations_dict = defaultdict(lambda: defaultdict(float))  # Python floats are double-precision, so representing the integer-valued 'n_samples' this way is fine.
 
     for name, module in model.named_modules():
-        if layers_to_save is None or name in layers_to_save:
+        if _check_name(name, layers_to_save):
             module.register_forward_hook(
                 partial(save_activations_statistics, activations_dict, name)
             )
+
     return activations_dict
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
   name='flash-attention-softmax-n',
   packages=find_packages(exclude=['tests*']),
-  version='0.2.0',
+  version='0.2.1',
   license='GPLv3',
   description='CUDA and Triton implementations of Flash Attention with SoftmaxN.',
   author='Christopher W. Murphy',

--- a/tests/cpu/analysis/test_hooks.py
+++ b/tests/cpu/analysis/test_hooks.py
@@ -7,17 +7,15 @@ from flash_attention_softmax_n.analysis.hooks import register_activation_hooks, 
 
 
 class Transformer(Module):
-    def __init__(self, return_inputs: bool = False):
+    def __init__(self):
         super().__init__()
-        self.return_inputs = return_inputs
         self.linear1 = Linear(32, 16)
         self.linear2 = Linear(16, 7)
 
     def forward(self, q, k, v):
         fa = flash_attention_n(q, k, v)
         l1 = self.linear1(fa)
-        l2 = self.linear2(l1)
-        return l2, q, k, v if self.return_inputs else l2
+        return self.linear2(l1)
 
 
 @mark.parametrize("acts_to_save", [None, "linear1,linear2"])
@@ -37,8 +35,6 @@ def test_register_activation_hooks(acts_to_save):
         value = randn((batch_size, 1, 1152, 32))
 
         model(query, key, value)
-
-    print(saved_activations)
 
     assert len(saved_activations) == 0 if to_save is None else len(to_save)
 


### PR DESCRIPTION
Previously, when no value for `layers_to_save` was passed to `register_activation_hooks`, it would register all named modules. This was problematic because not all modules output a tensor, and so an AttributeError would be thrown. 

This update provides a default value for `layers_to_save`, and also uses a try, except block in `save_activations_statistics`.

Also, I've switched the output of `register_activation_hooks` from being a dictionary of lists to a dictionary of dictionaries such that all of the statistics are labeled now.