### PR TITLE
added XLNet to surgery registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ trainer = composer.trainer.Trainer(
 ```
 
 Add your model to the registry!
-(Currently, only BERT and RoBERTa without flash attention are available by default.)
+Currently, only BERT, RoBERTa, and XLNet without flash attention are available by default.
 As an example, use `policy_registry` to replace slow_attention_0 in `MyModel` with flash_attention_n.
 After registration, wrap the model in `apply_attention_softmax_n`.
 ```python

--- a/flash_attention_softmax_n/surgery/surgery_functions/__init__.py
+++ b/flash_attention_softmax_n/surgery/surgery_functions/__init__.py
@@ -1,5 +1,6 @@
 try:
     from flash_attention_softmax_n.surgery.surgery_functions import _bert
+    from flash_attention_softmax_n.surgery.surgery_functions import _xlnet
     from flash_attention_softmax_n.surgery.surgery_functions.utils import policy_registry
 
     __all__ = ['policy_registry']

--- a/flash_attention_softmax_n/surgery/surgery_functions/_xlnet.py
+++ b/flash_attention_softmax_n/surgery/surgery_functions/_xlnet.py
@@ -1,0 +1,75 @@
+from types import MethodType
+
+from torch import einsum, float16
+from torch.nn import Module
+from transformers.models.xlnet.modeling_xlnet import XLNetRelativeAttention
+
+from flash_attention_softmax_n import softmax_n
+from flash_attention_softmax_n.surgery.surgery_functions.utils import policy_registry
+
+
+@policy_registry.register(XLNetRelativeAttention)
+def xlnet_attention_converter(module: Module, module_index: int, softmax_n_param: float) -> Module:
+    """Adds AttentionSoftmaxN to XLNet RelativeAttention."""
+    assert isinstance(module, (XLNetRelativeAttention,))
+    del module_index  # unused
+
+    if softmax_n_param < 0.:
+        raise ValueError(f"Softmax `n` parameter must be non-negative, found n={softmax_n_param}.")
+    module.n = softmax_n_param
+
+    setattr(module, 'rel_attn_core', MethodType(rel_attn_core, module))
+    return module
+
+
+def rel_attn_core(
+    self,
+    q_head,
+    k_head_h,
+    v_head_h,
+    k_head_r,
+    seg_mat=None,
+    attn_mask=None,
+    head_mask=None,
+    output_attentions=False,
+):
+    """Core relative positional attention operations."""
+
+    # content based attention score
+    ac = einsum("ibnd,jbnd->bnij", q_head + self.r_w_bias, k_head_h)
+
+    # position based attention score
+    bd = einsum("ibnd,jbnd->bnij", q_head + self.r_r_bias, k_head_r)
+    bd = self.rel_shift_bnij(bd, klen=ac.shape[3])
+
+    # segment based attention score
+    if seg_mat is None:
+        ef = 0
+    else:
+        ef = einsum("ibnd,snd->ibns", q_head + self.r_s_bias, self.seg_embed)
+        ef = einsum("ijbs,ibns->bnij", seg_mat, ef)
+
+    # merge attention scores and perform masking
+    attn_score = (ac + bd + ef) * self.scale
+    if attn_mask is not None:
+        # attn_score = attn_score * (1 - attn_mask) - 1e30 * attn_mask
+        if attn_mask.dtype == float16:
+            attn_score = attn_score - 65500 * einsum("ijbn->bnij", attn_mask)
+        else:
+            attn_score = attn_score - 1e30 * einsum("ijbn->bnij", attn_mask)
+
+    # attention probability
+    attn_prob = softmax_n(attn_score, n=self.n, dim=3)  # *** modified by CWM ***
+    attn_prob = self.dropout(attn_prob)
+
+    # Mask heads if we want to
+    if head_mask is not None:
+        attn_prob = attn_prob * einsum("ijbn->bnij", head_mask)
+
+    # attention output
+    attn_vec = einsum("bnij,jbnd->ibnd", attn_prob, v_head_h)
+
+    if output_attentions:
+        return attn_vec, einsum("bnij->ijbn", attn_prob)
+
+    return attn_vec

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = '0.3.0'
+VERSION = '0.3.1'
 
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = '0.3.1'
+VERSION = '0.3.2'
 
 
 install_requires = [

--- a/tests/cpu/surgery/test_xlnet.py
+++ b/tests/cpu/surgery/test_xlnet.py
@@ -1,0 +1,48 @@
+from pytest import raises
+from torch import randn
+from torch.testing import assert_close
+from transformers import AutoModel
+
+from flash_attention_softmax_n.surgery import apply_attention_softmax_n
+from tests.common import device_name
+
+
+MODEL_NAME = 'hf-internal-testing/tiny-random-XLNetModel'  # a tiny XLNet for testing purposes
+INPUT_TENSOR_SIZE = (2, 3, 32)  # the size of the input embedding to XLNet
+
+
+def test_xlnet(device_name):
+    # load the tiny XLNet
+    original_model = AutoModel.from_pretrained(MODEL_NAME)
+
+    # load the same XLNet and "operate" on its `rel_attn_core` method, but continue to use softmax_0
+    new_model_0 = AutoModel.from_pretrained(MODEL_NAME)
+    apply_attention_softmax_n(model=new_model_0, softmax_n_param=0.)
+
+    for layer_idx in range(new_model_0.config.num_hidden_layers):
+        # new model should have `n` parameter with `n == 0`
+        assert new_model_0.layer[layer_idx].rel_attn.n == 0.
+
+        # original model should not have `n` parameter
+        with raises(AttributeError):
+            original_model.layer[layer_idx].rel_attn.n
+
+        inputs_embeds = randn(size=INPUT_TENSOR_SIZE)
+        original_ouptut = original_model(inputs_embeds=inputs_embeds)
+        new_output_0 = new_model_0(inputs_embeds=inputs_embeds)
+        # new model with `n == 0` should produce the same output as the original model
+        assert_close(new_output_0, original_ouptut)
+
+    # load the same XLNet and "operate" on its `rel_attn_core` method, and now use softmax_1
+    new_model_1 = AutoModel.from_pretrained(MODEL_NAME)
+    apply_attention_softmax_n(model=new_model_1, softmax_n_param=1.)
+
+    for layer_idx in range(new_model_1.config.num_hidden_layers):
+        # new model should have `n` paramter with `n == 1`
+        assert new_model_1.layer[layer_idx].rel_attn.n == 1.
+
+        inputs_embeds = randn(size=INPUT_TENSOR_SIZE)
+        new_output_1 = new_model_1(inputs_embeds=inputs_embeds)
+        new_output_0 = new_model_0(inputs_embeds=inputs_embeds)
+        # the output with `n == 1` should be different than when `n == 0`
+        assert new_output_1[0].sum() != new_output_0[0].sum()


### PR DESCRIPTION
There was a [request](https://www.linkedin.com/feed/update/urn:li:activity:7105562277017202688?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7105562277017202688%2C7105777083288571904%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287105777083288571904%2Curn%3Ali%3Aactivity%3A7105562277017202688%29) on LinkedIn from Rami to give XLNet the "one-line treatment."

What that means is someone would be able to convert their XLNet model from softmax_0 to softmax_n by adding just one line of code to their script (or two lines if you count the import statement). For example,
```
import transformers

from flash_attention_softmax_n.surgery import apply_attention_softmax_n


model = transformers.AutoModel.from_pretrained('xlnet-base-cased')
apply_attention_softmax_n(model=model, softmax_n_param=1.)
...
```

On the backend, the `_xlnet` subpackage contains the modified `rel_attn_core` method code. It also adds the `XLNetRelativeAttention` class to the policy registry such that `apply_attention_softmax_n` and `AttentionSoftmaxN` know to operate on it.

As far as testing, the unit tests in `tests/cpu/surgery/test_xlnet.py` all pass. The tests in the `cpu` subpackage will run on a cpu or gpu. (The `gpu` subpackage tests are gpu-only.)